### PR TITLE
Add RL agent with training script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,3 +18,10 @@ Pour lancer la simulation simplement :
 ```bash
 python moto.py
 ```
+
+## Entra\xeenement par renforcement (RL)
+Pour entraîner un agent de contrôle via RL et visualiser les métriques dans TensorBoard :
+```bash
+python train_rl.py
+tensorboard --logdir=runs
+```

--- a/rl_agent.py
+++ b/rl_agent.py
@@ -1,0 +1,57 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torch.distributions as distributions
+import torch.nn.functional as F
+
+
+class PolicyNetwork(nn.Module):
+    """Policy network returning action probabilities."""
+
+    def __init__(self, hidden_size: int = 32, num_actions: int = 3):
+        super().__init__()
+        self.fc1 = nn.Linear(1, hidden_size)
+        self.fc2 = nn.Linear(hidden_size, num_actions)
+
+    def forward(self, state: torch.Tensor) -> torch.Tensor:
+        x = torch.relu(self.fc1(state))
+        return torch.softmax(self.fc2(x), dim=-1)
+
+
+class RLAgent:
+    def __init__(self, lr: float = 1e-3, gamma: float = 0.99, device: str = "cpu"):
+        self.policy = PolicyNetwork().to(device)
+        self.optimizer = optim.Adam(self.policy.parameters(), lr=lr)
+        self.gamma = gamma
+        self.device = device
+
+    def select_action(self, state: float):
+        state_tensor = torch.tensor([[state]], dtype=torch.float32, device=self.device)
+        probs = self.policy(state_tensor).squeeze(0)
+        dist = distributions.Categorical(probs)
+        action = dist.sample()
+        log_prob = dist.log_prob(action)
+        if action.item() == 0:  # accelerate
+            throttle, brake = 1.0, 0.0
+        elif action.item() == 1:  # brake
+            throttle, brake = 0.0, 1.0
+        else:  # idle
+            throttle, brake = 0.0, 0.0
+        return throttle, brake, log_prob
+
+    def update(self, log_probs, rewards):
+        returns = []
+        R = 0.0
+        for r in reversed(rewards):
+            R = r + self.gamma * R
+            returns.insert(0, R)
+        returns = torch.tensor(returns, dtype=torch.float32, device=self.device)
+        if returns.numel() > 1:
+            returns = (returns - returns.mean()) / (returns.std() + 1e-5)
+        loss = -(torch.stack(log_probs) * returns).sum()
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+
+
+

--- a/tests/test_motorcycle.py
+++ b/tests/test_motorcycle.py
@@ -4,6 +4,8 @@ import torch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from moto import Motorcycle
+from train_rl import train_rl_agent, evaluate_agent
+from rl_agent import RLAgent
 
 def test_speed_increases_with_throttle():
     m = Motorcycle(mass_std=1e-3, device='cpu')
@@ -26,3 +28,13 @@ def test_speed_decreases_with_brake():
     for _ in range(5):
         m.forward(throttle=0.0, brake=1.0, dt=dt)
     assert m.speed.item() < speed_before_brake
+
+
+def test_rl_agent_converges():
+    untrained = RLAgent(device='cpu')
+    initial_speed = evaluate_agent(untrained, seed=0)
+
+    agent = train_rl_agent(episodes=20, seed=0)
+    trained_speed = evaluate_agent(agent, seed=0)
+
+    assert trained_speed > initial_speed

--- a/train_rl.py
+++ b/train_rl.py
@@ -1,0 +1,57 @@
+import numpy as np
+import torch
+from torch.utils.tensorboard import SummaryWriter
+
+from moto import Motorcycle, DT, SIMULATION_TIME, TARGET_SPEED, device
+from rl_agent import RLAgent
+
+
+def train_rl_agent(episodes: int = 200, seed: int = 0):
+    """Train an RL agent to reach TARGET_SPEED."""
+    torch.manual_seed(seed)
+    motorcycle = Motorcycle(device=device, mass_std=1e-3)
+    agent = RLAgent(device=device)
+    writer = SummaryWriter()
+    steps = int(SIMULATION_TIME / DT)
+
+    for ep in range(episodes):
+        motorcycle.reset()
+        state = motorcycle.speed.item()
+        log_probs = []
+        rewards = []
+        speeds = []
+        for _ in range(steps):
+            throttle, brake, log_prob = agent.select_action(state)
+            speed = motorcycle(throttle, brake, DT)
+            reward = -((speed - TARGET_SPEED) ** 2).item()
+            log_probs.append(log_prob)
+            rewards.append(reward)
+            speeds.append(speed.item())
+            state = speed.item()
+        agent.update(log_probs, rewards)
+        writer.add_scalar("Episode Reward", sum(rewards), ep)
+        writer.add_scalar("Average Speed", np.mean(speeds), ep)
+    writer.close()
+    return agent
+
+
+def evaluate_agent(agent: RLAgent, episodes: int = 1, seed: int = 0) -> float:
+    """Return average final speed of the agent."""
+    torch.manual_seed(seed)
+    motorcycle = Motorcycle(device=agent.device, mass_std=1e-3)
+    steps = int(SIMULATION_TIME / DT)
+    final_speeds = []
+    for _ in range(episodes):
+        motorcycle.reset()
+        state = motorcycle.speed.item()
+        for _ in range(steps):
+            throttle, brake, _ = agent.select_action(state)
+            speed = motorcycle(throttle, brake, DT)
+            state = speed.item()
+        final_speeds.append(motorcycle.speed.item())
+    return float(np.mean(final_speeds))
+
+
+if __name__ == "__main__":
+    train_rl_agent()
+


### PR DESCRIPTION
## Summary
- implement a small policy-gradient RL agent in `rl_agent.py`
- add `train_rl.py` to train the agent and log metrics with TensorBoard
- extend tests to train the agent briefly and ensure it improves
- document how to train the RL agent in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851dc613a18833299343729a1f19aff